### PR TITLE
Compiling with PIE which is needed for Android 5.0+

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -9,6 +9,9 @@ LOCAL_MODULE:= bonnie
 
  LOCAL_CFLAGS +=		\
 	-D__ARM__			\
-	-DIS_ANDROID=1
+	-DIS_ANDROID=1		\
+	-fPIE
+
+LOCAL_LDFLAGS += -pie
 
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
I made this small change to get this to work for an Android 5.1.1 device that I use.
